### PR TITLE
Add flag for registering Rollbar exception handler.

### DIFF
--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -62,7 +62,7 @@ public class Notifier {
     private RollbarThread rollbarThread;
     
 
-    public Notifier(Context context, String accessToken, String environment) {
+    public Notifier(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
         scheduler = Executors.newSingleThreadScheduledExecutor();
         
         this.accessToken = accessToken;
@@ -89,8 +89,10 @@ public class Notifier {
         
         queuedItemDirectory = new File(context.getCacheDir(), ITEM_DIR_NAME);
         queuedItemDirectory.mkdirs();
-        
-        RollbarExceptionHandler.register(this);
+
+        if (registerExceptionHandler) {
+            RollbarExceptionHandler.register(this);
+        }
 
         rollbarThread = new RollbarThread(this);
         rollbarThread.start();
@@ -102,7 +104,7 @@ public class Notifier {
         JSONArray log = null;
         
         int pid = android.os.Process.myPid();
-        
+
         try {
             Process process = Runtime.getRuntime().exec("logcat -d");
             

--- a/src/main/java/com/rollbar/android/Rollbar.java
+++ b/src/main/java/com/rollbar/android/Rollbar.java
@@ -13,10 +13,14 @@ public class Rollbar {
     private static Notifier notifier;
 
     public static void init(Context context, String accessToken, String environment) {
+        init(context, accessToken, environment, true);
+    }
+
+    public static void init(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
         if (isInit()) {
             Log.w(TAG, "Rollbar.init() called when it was already initialized.");
         } else {
-            notifier = new Notifier(context, accessToken, environment);
+            notifier = new Notifier(context, accessToken, environment, registerExceptionHandler);
         }
     }
 


### PR DESCRIPTION
This change adds a flag which controls whether you want to register
rollbar's uncaught exception handler. By default it is on using the
existing constructor.