### PR TITLE
Multiple quality improvements

### DIFF
--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -34,6 +34,10 @@ public class Notifier {
     private static final String NOTIFIER_VERSION = "0.1.2";
     private static final String DEFAULT_ENDPOINT = "https://api.rollbar.com/api/1/items/";
     private static final String ITEM_DIR_NAME = "rollbar-items";
+    private static final String PAYLOAD_ERROR_MSG = "There was an error constructing the JSON payload.";
+    private static final String ANDROID = "android";
+    private static final String MESSAGE = "message";
+    
     
     private static final int DEFAULT_ITEM_SCHEDULE_DELAY = 1;
     private static final int MAX_LOGCAT_SIZE = 100;
@@ -42,10 +46,10 @@ public class Notifier {
     
     volatile private boolean handlerScheduled;
     
-    private ScheduledExecutorService scheduler;
+    private final ScheduledExecutorService scheduler;
 
-    private String accessToken;
-    private String environment;
+    private final String accessToken;
+    private final String environment;
 
     private JSONObject personData;
     private String endpoint;
@@ -58,8 +62,8 @@ public class Notifier {
     private int versionCode;
     private String versionName;
     
-    private File queuedItemDirectory;
-    private RollbarThread rollbarThread;
+    private final File queuedItemDirectory;
+    private final RollbarThread rollbarThread;
     
 
     public Notifier(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
@@ -160,7 +164,7 @@ public class Notifier {
             androidData.put("logs", getLogcatInfo());
         }
         
-        client.put("android", androidData);
+        client.put(ANDROID, androidData);
         client.put("user_ip", "$remote_ip");
 
         return client;
@@ -171,8 +175,8 @@ public class Notifier {
 
         data.put("environment", this.environment);
         data.put("level", level);
-        data.put("platform", "android");
-        data.put("framework", "android");
+        data.put("platform", ANDROID);
+        data.put("framework", ANDROID);
         data.put("language", "java");
 
         data.put("body", body);
@@ -253,7 +257,7 @@ public class Notifier {
         try {
             payload = buildPayload(items);
         } catch (JSONException e) {
-            Log.e(Rollbar.TAG, "There was an error constructing the JSON payload.", e);
+            Log.e(Rollbar.TAG, PAYLOAD_ERROR_MSG, e);
             return;
         }
         
@@ -351,7 +355,7 @@ public class Notifier {
 
         JSONObject exceptionData = new JSONObject();
         exceptionData.put("class", throwable.getClass().getName());
-        exceptionData.put("message", throwable.getMessage());
+        exceptionData.put(MESSAGE, throwable.getMessage());
 
         if (!TextUtils.isEmpty(description)) {
         	exceptionData.put("description", description);
@@ -410,7 +414,7 @@ public class Notifier {
 
             return buildData(level, body);
         } catch (JSONException e) {
-            Log.e(Rollbar.TAG, "There was an error constructing the JSON payload.", e);
+            Log.e(Rollbar.TAG, PAYLOAD_ERROR_MSG, e);
             return null;
         }
     }
@@ -421,11 +425,11 @@ public class Notifier {
             JSONObject messageBody = new JSONObject();
 
             messageBody.put("body", message);
-            body.put("message", messageBody);
+            body.put(MESSAGE, messageBody);
 
             return buildData(level, body);
         } catch (JSONException e) {
-            Log.e(Rollbar.TAG, "There was an error constructing the JSON payload.", e);
+            Log.e(Rollbar.TAG, PAYLOAD_ERROR_MSG, e);
             return null;
         }
     }
@@ -436,14 +440,14 @@ public class Notifier {
             JSONObject messageBody = new JSONObject();
             
             messageBody.put("body", message);
-            body.put("message", messageBody);
+            body.put(MESSAGE, messageBody);
             
-            for(String key : params.keySet()){
-                messageBody.put(key, params.get(key));
+            for(Map.Entry<String, String> stringEntry : params.entrySet()){
+                messageBody.put(stringEntry.getKey(), stringEntry.getValue());
             }
             return buildData(level, body);
         } catch (JSONException e) {
-            Log.e(Rollbar.TAG, "There was an error constructing the JSON payload.", e);
+            Log.e(Rollbar.TAG, PAYLOAD_ERROR_MSG, e);
             return null;
         }
     }

--- a/src/main/java/com/rollbar/android/RollbarExceptionHandler.java
+++ b/src/main/java/com/rollbar/android/RollbarExceptionHandler.java
@@ -3,8 +3,8 @@ package com.rollbar.android;
 import java.lang.Thread.UncaughtExceptionHandler;
 
 public class RollbarExceptionHandler implements UncaughtExceptionHandler {
-    private UncaughtExceptionHandler existingHandler;
-    private Notifier notifier;
+    private final UncaughtExceptionHandler existingHandler;
+    private final Notifier notifier;
 
     private RollbarExceptionHandler(UncaughtExceptionHandler existingHandler, Notifier notifier) {
         this.existingHandler = existingHandler;

--- a/src/main/java/com/rollbar/android/RollbarThread.java
+++ b/src/main/java/com/rollbar/android/RollbarThread.java
@@ -11,8 +11,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class RollbarThread extends Thread {
-    private List<JSONObject> queue;
-    private Notifier notifier;
+    private final List<JSONObject> queue;
+    private final Notifier notifier;
     
     private final Lock lock = new ReentrantLock();
     private final Condition ready = lock.newCondition();

--- a/src/main/java/com/rollbar/android/http/HttpRequest.java
+++ b/src/main/java/com/rollbar/android/http/HttpRequest.java
@@ -19,11 +19,11 @@ public class HttpRequest implements Runnable {
     private static final int REQUEST_TIMEOUT = 5000;
 
 
-    private URL url;
-    private HttpResponseHandler handler;
+    private final URL url;
+    private final HttpResponseHandler handler;
 
     private HttpURLConnection connection;
-    private HashMap<String, String> requestProperties;
+    private final HashMap<String, String> requestProperties;
 
     private String method;
     private byte[] body;
@@ -120,7 +120,7 @@ public class HttpRequest implements Runnable {
     private String getResponseText(InputStream in) throws IOException {
         byte[] contents = new byte[1024];
 
-        int bytesRead = 0;
+        int bytesRead;
         String response = "";
 
         while ((bytesRead = in.read(contents)) != -1) {

--- a/src/main/java/com/rollbar/android/http/HttpRequestManager.java
+++ b/src/main/java/com/rollbar/android/http/HttpRequestManager.java
@@ -14,8 +14,8 @@ public class HttpRequestManager {
     public static final int MAX_RETRIES = 5;
     
     private static HttpRequestManager instance = null;
-    private ThreadPoolExecutor executor;
-    private ScheduledExecutorService service;
+    private final ThreadPoolExecutor executor;
+    private final ScheduledExecutorService service;
 
     private HttpRequestManager() {
         executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();

--- a/src/main/java/com/rollbar/android/http/HttpResponse.java
+++ b/src/main/java/com/rollbar/android/http/HttpResponse.java
@@ -1,10 +1,10 @@
 package com.rollbar.android.http;
 
 public class HttpResponse {
-    private String result;
+    private final String result;
     
-    private int statusCode;
-    private String responseText;
+    private final int statusCode;
+    private final String responseText;
     
     public HttpResponse(String result) {
         this.result = result;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2864 - "entrySet()" should be iterated when both the key and value are needed
squid:S1192 - String literals should not be duplicated
squid:S1854 - Dead stores should be removed
pmd:ImmutableField - Immutable Field


You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1192
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1854
https://dev.eclipse.org/sonar/coding_rules#q=pmd:ImmutableField

Please let me know if you have any questions.

M-Ezzat