### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -5,10 +5,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +114,7 @@ public class Notifier {
         try {
             Process process = Runtime.getRuntime().exec("logcat -d");
             
-            InputStreamReader isr = new InputStreamReader(process.getInputStream());
+            InputStreamReader isr = new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8);
             BufferedReader br = new BufferedReader(isr, 8192);
             
             List<String> lines = new ArrayList<String>();
@@ -211,7 +213,7 @@ public class Notifier {
             
             byte[] buffer = new byte[1024];
             while (in.read(buffer) != -1) {
-                content.append(new String(buffer));
+                content.append(new String(buffer, StandardCharsets.UTF_8));
             }
             
             in.close();
@@ -237,8 +239,9 @@ public class Notifier {
         try {
             String filename = itemCounter++ + "." + System.currentTimeMillis();
             File file = new File(queuedItemDirectory, filename);
-            FileWriter writer = new FileWriter(file);
-            
+            FileOutputStream fileOutputStream = new FileOutputStream(file);
+            OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
+
             writer.write(items.toString());
             writer.close();
 
@@ -342,7 +345,7 @@ public class Notifier {
 
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintStream ps = new PrintStream(baos);
+            PrintStream ps = new PrintStream(baos, false, "UTF-8");
 
             throwable.printStackTrace(ps);
             ps.close();

--- a/src/main/java/com/rollbar/android/http/HttpRequest.java
+++ b/src/main/java/com/rollbar/android/http/HttpRequest.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
@@ -124,7 +125,7 @@ public class HttpRequest implements Runnable {
         String response = "";
 
         while ((bytesRead = in.read(contents)) != -1) {
-            response = response.concat(new String(contents, 0, bytesRead));
+            response = response.concat(new String(contents, 0, bytesRead, StandardCharsets.UTF_8));
         }
 
         return response;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
