### PR TITLE
add allow to customize Rollbar thread name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,6 @@
-# Change Log
+# Changelog for ceph3us-features branch fork of Rollbar for Android 
 
-**0.1.3**
-- Add pom.xml with metadata for Maven Central
+**0.1.3-bc**
+- initial release.
+- add allow to customize Rollbar thread name to be more friendly and  better recognizable as default one 
 
-**0.1.2**
-- Added flag to `Rollbar.init()` to enable/disable the registration of the uncaught exception handler. (pr#17)
-
-**0.1.1**
-- Added reportMessage(message, level, params) to send extra params with messages. (pr#10)
-
-**0.1.0**
-- Fixed build.xml, changed `code_version` parameter. (pr#11)
-- `code_version` now properly refers to the [versionName](http://developer.android.com/reference/android/content/pm/PackageInfo.html#versionName) attribute from the manifest file.
-
-**0.0.6**
-- Added ability to provide a description for caught exceptions. Usage: [https://github.com/rollbar/rollbar-android#usage](https://github.com/rollbar/rollbar-android#usage)
-- Added isInit() method to check to see if Rollbar is initialized.
-
-**0.0.5**
-- Exceptions with causing exceptions will now be sent with all the causes chained together in a single item. These multiple exceptions will all appear in the proper order in the Rollbar interface.
-- Uncaught exceptions are now saved to disk instead of immediately being reported, to prevent any blocking of the app shutdown process. A new configuration option exists to revert to the old behavior.
-
-**0.0.4**
-- Ability to include logcat output for every item reported.
-- Ability to set person data.
-- Caught exception level now defaults to warning, new configuration options available to change this and uncaught exception level.
-
-**0.0.3**
-- New persistence system to support retries of item payloads not sent due to network connectivity issues.
-
-**0.0.2**
-- Use JSON objects and arrays instead of HashMaps and ArrayLists for payload construction.
-- Set reportUncaughtExceptions to true by default.
-
-**0.0.1**
-- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog for ceph3us-features branch fork of Rollbar for Android 
 
-**0.1.3-bc**
+**0.1.3bc1**
 - initial release.
-- add allow to customize Rollbar thread name to be more friendly and  better recognizable as default one 
-
+- add allow to customize Rollbar thread name to be more friendly and  better recognizable as default one
+ 
+**0.1.3bc4**
+- add predefined levels eg: Rollbar.Level.DEBUG
+- rewrite RollbarThread include: 
+    - concurrency logic first step to minimize deadlocking  
+    - more verbosity for debugging     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rollbar for Android
+# ceph3us fork of Rollbar for Android
 
 <!-- RemoveNext -->
 Java library for reporting exceptions, errors, and log messages to [Rollbar](https://rollbar.com).
@@ -12,9 +12,9 @@ Install from Maven central:
 ```
 <dependencies>
   <dependency>
-    <groupId>com.rollbar</groupId>
+    <groupId>pl.ceph3us.projects.android</groupId>
      <artifactId>rollbar</artifactId>
-     <version>0.1.3</version>
+     <version>0.1.3-bc</version>
   </dependency>
 </dependencies>
 ```
@@ -22,19 +22,19 @@ Install from Maven central:
 or
 
 ```
-compile 'com.rollbar:rollbar-android:0.1.3'
+compile 'pl.ceph3us.projects.android.rollbar:rollbar:0.1.3-bc'
 ```
 
 ### Jar
 
-Download [rollbar-android.jar](https://github.com/rollbar/rollbar-android/releases/latest) and place it in your Android project's `libs` directory.
+Download [rollbar.jar](https://github.com/c3ph3us/rollbar/releases/latest) and place it in your Android project's `libs` directory.
 
 Add the following line in your custom Application subclass's `onCreate()` to initialize Rollbar:
 
 ```java
-Rollbar.init(this, "POST_CLIENT_ITEM_ACCESS_TOKEN", "production");
+Rollbar.init(this, "MyCustomRollbarThreadName", "POST_CLIENT_ITEM_ACCESS_TOKEN", "production");
 ```
-
+if you don't want to customize rollbar thread name just omit it.
 
 Make sure your `AndroidManifest.xml` contains the `android.permission.INTERNET` permission.
 
@@ -144,7 +144,7 @@ By default, file names and line numbers are removed by ProGuard. To preserve thi
 
 ## Help / Support
 
-If you run into any issues, please email us at `support@rollbar.com`
+If you run into any problem please fill issue.
 
 ## Build
 

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: 
+

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,3 +1,2 @@
 Manifest-Version: 1.0
-Main-Class: 
 

--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -32,7 +32,7 @@ import com.rollbar.android.http.HttpResponse;
 import com.rollbar.android.http.HttpResponseHandler;
 
 public class Notifier {
-    private static final String NOTIFIER_VERSION = "0.1.2";
+    private static final String NOTIFIER_VERSION = "0.1.3bc4";
     private static final String DEFAULT_ENDPOINT = "https://api.rollbar.com/api/1/items/";
     private static final String ITEM_DIR_NAME = "rollbar-items";
     private static final String PAYLOAD_ERROR_MSG = "There was an error constructing the JSON payload.";

--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -67,10 +67,6 @@ public class Notifier {
     private final RollbarThread rollbarThread;
     protected final String rollbarThreadName;
 
-    public Notifier(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
-        this(context,null,accessToken,environment,registerExceptionHandler);
-    }
-
     public Notifier(Context context,  String rollbarThreadName, String accessToken, String environment, boolean registerExceptionHandler) {
         scheduler = Executors.newSingleThreadScheduledExecutor();
 

--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -65,11 +65,16 @@ public class Notifier {
     
     private final File queuedItemDirectory;
     private final RollbarThread rollbarThread;
-    
+    protected final String rollbarThreadName;
 
     public Notifier(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
+        this(context,null,accessToken,environment,registerExceptionHandler);
+    }
+
+    public Notifier(Context context,  String rollbarThreadName, String accessToken, String environment, boolean registerExceptionHandler) {
         scheduler = Executors.newSingleThreadScheduledExecutor();
-        
+
+        this.rollbarThreadName = rollbarThreadName;
         this.accessToken = accessToken;
         this.environment = environment;
         

--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -175,7 +175,7 @@ public class Notifier {
     private JSONObject buildData(String level, JSONObject body) throws JSONException {
         JSONObject data = new JSONObject();
 
-        data.put("environment", this.environment);
+        data.put("environment", this.environment); // do we need put null ? waste of time put cost
         data.put("level", level);
         data.put("platform", ANDROID);
         data.put("framework", ANDROID);

--- a/src/main/java/com/rollbar/android/Notifier.java
+++ b/src/main/java/com/rollbar/android/Notifier.java
@@ -32,7 +32,8 @@ import com.rollbar.android.http.HttpResponse;
 import com.rollbar.android.http.HttpResponseHandler;
 
 public class Notifier {
-    private static final String NOTIFIER_VERSION = "0.1.3bc4";
+    // consider other solution for versioning
+    private static final String NOTIFIER_VERSION = "0.1.4";
     private static final String DEFAULT_ENDPOINT = "https://api.rollbar.com/api/1/items/";
     private static final String ITEM_DIR_NAME = "rollbar-items";
     private static final String PAYLOAD_ERROR_MSG = "There was an error constructing the JSON payload.";
@@ -66,6 +67,10 @@ public class Notifier {
     private final File queuedItemDirectory;
     private final RollbarThread rollbarThread;
     protected final String rollbarThreadName;
+
+    public Notifier(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
+        this(context,null,accessToken,environment,registerExceptionHandler);
+    }
 
     public Notifier(Context context,  String rollbarThreadName, String accessToken, String environment, boolean registerExceptionHandler) {
         scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -175,7 +180,7 @@ public class Notifier {
     private JSONObject buildData(String level, JSONObject body) throws JSONException {
         JSONObject data = new JSONObject();
 
-        data.put("environment", this.environment); // do we need put null ? waste of time put cost
+        data.put("environment", this.environment);
         data.put("level", level);
         data.put("platform", ANDROID);
         data.put("framework", ANDROID);

--- a/src/main/java/com/rollbar/android/Rollbar.java
+++ b/src/main/java/com/rollbar/android/Rollbar.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import org.json.JSONObject;
 
+import java.util.IllegalFormatCodePointException;
 import java.util.Map;
 
 public class Rollbar {
@@ -12,12 +13,21 @@ public class Rollbar {
 
     private static Notifier notifier;
 
+    // prevent user pointless object initialization
+    private Rollbar() {
+        throw new IllegalStateException("This class has static initializer and can't be initialized using this constructor!");
+    }
+
     public static void init(Context context, String accessToken, String environment) {
         init(context, null, accessToken, environment, true);
     }
 
     public static void init(Context context, String rollbarThreadName, String accessToken, String environment) {
         init(context, rollbarThreadName, accessToken, environment, true);
+    }
+
+    public static void init(Context context, String accessToken, String environment,  boolean registerExceptionHandle) {
+        init(context, null, accessToken, environment, registerExceptionHandle);
     }
 
     public static void init(Context context, String rollbarThreadName, String accessToken, String environment, boolean registerExceptionHandler) {

--- a/src/main/java/com/rollbar/android/Rollbar.java
+++ b/src/main/java/com/rollbar/android/Rollbar.java
@@ -5,10 +5,28 @@ import android.util.Log;
 
 import org.json.JSONObject;
 
-import java.util.IllegalFormatCodePointException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Map;
 
+// TODO: 19.10.16
+// 1) prevent pointless thread running - we can hook in exc handler
+// 2) ad 2/ re-route user global thread exc handler if set !
+// 3) make report object to avoid to many methods
+
 public class Rollbar {
+
+    // predefined levels - later we add indef annotation
+    //@IntDef({MERCURY, VENUS, EARTH, MARS, JUPITER, SATURN, URANUS, NEPTUNE})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Level {
+        String CRITICAL = "Critical";
+        String ERROR = "Error";
+        String WARNING = "Warning";
+        String INFO = "Info";
+        String DEBUG = "Debug";
+    }
+
     public static final String TAG = "Rollbar";
 
     private static Notifier notifier;
@@ -26,7 +44,7 @@ public class Rollbar {
         init(context, rollbarThreadName, accessToken, environment, true);
     }
 
-    public static void init(Context context, String accessToken, String environment,  boolean registerExceptionHandle) {
+    public static void init(Context context, String accessToken, String environment, boolean registerExceptionHandle) {
         init(context, null, accessToken, environment, registerExceptionHandle);
     }
 
@@ -42,7 +60,7 @@ public class Rollbar {
         return notifier != null;
     }
 
-    public static void reportException(final Throwable throwable, final String level, final String description) {
+    public static void reportException(final Throwable throwable, @Level final String level, final String description) {
         ensureInit(new Runnable() {
             public void run() {
                 notifier.reportException(throwable, level, description);
@@ -50,7 +68,7 @@ public class Rollbar {
         });
     }
 
-    public static void reportException(final Throwable throwable, final String level, final String description, final Map<String, String> params) {
+    public static void reportException(final Throwable throwable, @Level final String level, final String description, final Map<String, String> params) {
         ensureInit(new Runnable() {
             public void run() {
                 notifier.reportException(throwable, level, description, params);
@@ -58,7 +76,7 @@ public class Rollbar {
         });
     }
 
-    public static void reportException(final Throwable throwable, final String level) {
+    public static void reportException(final Throwable throwable, @Level final String level) {
         reportException(throwable, level, null);
     }
 
@@ -66,7 +84,7 @@ public class Rollbar {
         reportException(throwable, null, null);
     }
 
-    public static void reportMessage(final String message, final String level) {
+    public static void reportMessage(final String message, @Level final String level) {
         ensureInit(new Runnable() {
             public void run() {
                 notifier.reportMessage(message, level);
@@ -74,7 +92,7 @@ public class Rollbar {
         });
     }
 
-    public static void reportMessage(final String message, final String level, final Map<String, String> params) {
+    public static void reportMessage(final String message, @Level final String level, final Map<String, String> params) {
         ensureInit(new Runnable() {
             public void run() {
                 notifier.reportMessage(message, level, params);
@@ -83,9 +101,9 @@ public class Rollbar {
     }
 
     public static void reportMessage(String message) {
-        reportMessage(message, "info");
+        reportMessage(message, Level.INFO);
     }
-    
+
     public static void setPersonData(final JSONObject personData) {
         ensureInit(new Runnable() {
             public void run() {
@@ -93,7 +111,7 @@ public class Rollbar {
             }
         });
     }
-    
+
     public static void setPersonData(final String id, final String username, final String email) {
         ensureInit(new Runnable() {
             public void run() {
@@ -101,7 +119,7 @@ public class Rollbar {
             }
         });
     }
-    
+
     public static void setEndpoint(final String endpoint) {
         ensureInit(new Runnable() {
             public void run() {
@@ -109,7 +127,7 @@ public class Rollbar {
             }
         });
     }
-    
+
     public static void setReportUncaughtExceptions(final boolean report) {
         ensureInit(new Runnable() {
             public void run() {
@@ -117,7 +135,7 @@ public class Rollbar {
             }
         });
     }
-    
+
     public static void setIncludeLogcat(final boolean includeLogcat) {
         ensureInit(new Runnable() {
             public void run() {
@@ -125,16 +143,16 @@ public class Rollbar {
             }
         });
     }
-    
-    public static void setDefaultCaughtExceptionLevel(final String level) {
+
+    public static void setDefaultCaughtExceptionLevel(@Level final String level) {
         ensureInit(new Runnable() {
             public void run() {
                 notifier.setDefaultCaughtExceptionLevel(level);
             }
         });
     }
-    
-    public static void setUncaughtExceptionLevel(final String level) {
+
+    public static void setUncaughtExceptionLevel(@Level final String level) {
         ensureInit(new Runnable() {
             public void run() {
                 notifier.setUncaughtExceptionLevel(level);
@@ -149,7 +167,7 @@ public class Rollbar {
             }
         });
     }
-    
+
     private static void ensureInit(Runnable runnable) {
         if (isInit()) {
             try {

--- a/src/main/java/com/rollbar/android/Rollbar.java
+++ b/src/main/java/com/rollbar/android/Rollbar.java
@@ -13,14 +13,18 @@ public class Rollbar {
     private static Notifier notifier;
 
     public static void init(Context context, String accessToken, String environment) {
-        init(context, accessToken, environment, true);
+        init(context, null, accessToken, environment, true);
     }
 
-    public static void init(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
+    public static void init(Context context, String rollbarThreadName, String accessToken, String environment) {
+        init(context, rollbarThreadName, accessToken, environment, true);
+    }
+
+    public static void init(Context context, String rollbarThreadName, String accessToken, String environment, boolean registerExceptionHandler) {
         if (isInit()) {
             Log.w(TAG, "Rollbar.init() called when it was already initialized.");
         } else {
-            notifier = new Notifier(context, accessToken, environment, registerExceptionHandler);
+            notifier = new Notifier(context, rollbarThreadName, accessToken, environment, registerExceptionHandler);
         }
     }
 

--- a/src/main/java/com/rollbar/android/Rollbar.java
+++ b/src/main/java/com/rollbar/android/Rollbar.java
@@ -38,11 +38,12 @@ public class Rollbar {
 
     public static void reportException(final Throwable throwable, final String level, final String description, final Map<String, String> params) {
         ensureInit(new Runnable() {
-                public void run() {
+            public void run() {
                 notifier.reportException(throwable, level, description, params);
             }
         });
-    
+    }
+
     public static void reportException(final Throwable throwable, final String level) {
         reportException(throwable, level, null);
     }

--- a/src/main/java/com/rollbar/android/Rollbar.java
+++ b/src/main/java/com/rollbar/android/Rollbar.java
@@ -9,10 +9,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Map;
 
-// TODO: 19.10.16
+// ceph3us TODO: 19.10.16
 // 1) prevent pointless thread running - we can hook in exc handler
-// 2) ad 2/ re-route user global thread exc handler if set !
+// 2) ad 2/ re-route user global thread exc handler if set!
 // 3) make report object to avoid to many methods
+// DONE 4) add predefined levels
+// DONE 5) concurrency locking correction
+// DONE 6) thread reporting verbosity
 
 public class Rollbar {
 

--- a/src/main/java/com/rollbar/android/RollbarThread.java
+++ b/src/main/java/com/rollbar/android/RollbarThread.java
@@ -3,7 +3,6 @@ package com.rollbar.android;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import android.util.Log;
@@ -11,60 +10,128 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class RollbarThread extends Thread {
-
+    // default thread name if not provided
     private final String DEFAULT_ROLLBAR_THREAD_NAME = "RollbarThread";
-
-    private final List<JSONObject> queue;
-    private final Notifier notifier;
-    
-    private final Lock lock = new ReentrantLock();
-    private final Condition ready = lock.newCondition();
-    
-    public RollbarThread(Notifier notifier) {
-        this.notifier = notifier;
-        queue = new ArrayList<JSONObject>();
-        setName(notifier.rollbarThreadName !=null
-                ? notifier.rollbarThreadName
-                : DEFAULT_ROLLBAR_THREAD_NAME);
+    // que why we do not use fifo lifo deque???
+    private final List<JSONObject> _queue;
+    // notifier
+    private final Notifier _notifier;
+    // lock
+    private final ReentrantLock _lock = new ReentrantLock();
+    // condition for lock
+    private final Condition _ready = _lock.newCondition();
+    // thread stored name def
+    private final String _rollbarThreadName;
+    // get thread stored name defined at object creation
+    public String getRollbarThreadName() {
+        return _rollbarThreadName;
     }
+
+    public RollbarThread(Notifier notifier) {
+        // set notifier
+        _notifier = notifier;
+        // create que object
+        _queue = new ArrayList<JSONObject>();
+        // determine and store thread name
+        // this is not perfect solution
+        // as setName(String) can be called as it is finall public android thread method
+        // but for now RollbarThread class is sealed from user...
+        _rollbarThreadName = notifier.rollbarThreadName != null
+                ? notifier.rollbarThreadName
+                : DEFAULT_ROLLBAR_THREAD_NAME;
+        // set thread name
+        setName(_rollbarThreadName);
+    }
+
 
     @Override
     public void run() {
-        for (;;) {
-            lock.lock();
-            
+        // log start
+        Log.d(Rollbar.TAG, getRollbarThreadName() + " started...");
+        // do main loop
+        while (true) {
             try {
-                if (queue.isEmpty()) {
-                    ready.await();
-                }
-
-                JSONArray items = new JSONArray(queue);
-                queue.clear();
-
-                lock.unlock();
-
-                notifier.postItems(items, null);
-            } catch (InterruptedException e) {
-                if (!queue.isEmpty()) {
-                    JSONArray items = new JSONArray(queue);
-                    queue.clear();
-
-                    // Save all remaining items to disk because the process is
-                    // dying soon
-                    notifier.writeItems(items);
-                }
-
-                break;
+                // send
+                postQue();
+            } catch  // catch interruption
+                    (InterruptedException e) {
+                // on interrupt allow exit graceful
+                // empty que
+                emptyQueToFile();
+                // log ending
+                Log.d(Rollbar.TAG, getRollbarThreadName() + " finishing.");
+                // restore interrupt state!
+                interrupt();
+                // allow thread dead
+                return;
             }
         }
-
-        Log.d(Rollbar.TAG, "Rollbar thread finishing.");
     }
-    
+
+    private void postQue() throws InterruptedException {
+        // lock
+        _lock.lock();
+        // do work
+        try {
+            // await signal
+            _ready.await();
+            // if interrupted
+            // check size
+            if (_queue.size() > 0) {
+                // log
+                Log.d(Rollbar.TAG, getRollbarThreadName() + " posting que...");
+                // make post object
+                JSONArray items = new JSONArray(_queue);
+                // post
+                _notifier.postItems(items, null);
+                // clear when we send data
+                _queue.clear();
+            }
+        } finally {
+            // interrupted or not, always release lock
+            _lock.unlock();
+        }
+    }
+
+    private void emptyQueToFile() {
+        // lock
+        _lock.lock();
+        // do work
+        try {
+            // check size
+            if (_queue.size() > 0) {
+                //
+                Log.d(Rollbar.TAG,  getRollbarThreadName() + " saving que...");
+                // make save post object
+                JSONArray items = new JSONArray(_queue);
+                // Save all remaining items to disk because the process is
+                // dying soon
+                _notifier.writeItems(items);
+                // then clear que
+                _queue.clear();
+            }
+        } finally {
+            // unlock
+            _lock.unlock();
+        }
+    }
+
     public void queueItem(JSONObject item) {
-        lock.lock();
-        queue.add(item);
-        ready.signal();
-        lock.unlock();
+        // lock
+        _lock.lock();
+        try {
+            // log who is adding to which que
+            Log.d(Rollbar.TAG, Thread.currentThread().getName() + " is adding data to " + getRollbarThreadName() + " que...");
+            // try add
+            _queue.add(item);
+            // check we can signal
+            if(_lock.isHeldByCurrentThread()) {
+                // signal
+                _ready.signal();
+            }
+        } finally {
+            // unlock
+            _lock.unlock();
+        }
     }
 }

--- a/src/main/java/com/rollbar/android/RollbarThread.java
+++ b/src/main/java/com/rollbar/android/RollbarThread.java
@@ -11,6 +11,9 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class RollbarThread extends Thread {
+
+    private final String DEFAULT_ROLLBAR_THREAD_NAME = "RollbarThread";
+
     private final List<JSONObject> queue;
     private final Notifier notifier;
     
@@ -20,6 +23,9 @@ public class RollbarThread extends Thread {
     public RollbarThread(Notifier notifier) {
         this.notifier = notifier;
         queue = new ArrayList<JSONObject>();
+        setName(notifier.rollbarThreadName !=null
+                ? notifier.rollbarThreadName
+                : DEFAULT_ROLLBAR_THREAD_NAME);
     }
 
     @Override


### PR DESCRIPTION
add allow to customize Rollbar thread name 
- to be more friendly 
- and better recognizable as default while debugging or tracking if rollbar self is causing any mess :) 

from 0.1.3bc-initial
(cherry picked from commit ccbe145)

ps. second try to add something to this dead zone :) 
