### PR TITLE
[#23] Make RollbarThread more correct

### DIFF
--- a/src/main/java/com/rollbar/android/RollbarThread.java
+++ b/src/main/java/com/rollbar/android/RollbarThread.java
@@ -39,6 +39,8 @@ public class RollbarThread extends Thread {
                     JSONArray items = new JSONArray(queue);
                     queue.clear();
                     lock.unlock();
+                    // Save all remaining items to disk because the process is
+                    // dying soon
                     notifier.writeItems(items);
                 } else {
                     lock.unlock();


### PR DESCRIPTION
RollbarThread was doing a few things that could lead to deadlocks by
misusing Java concurrency primatives. Testing a deadlock scenario is
pretty hard usually, especially because I am not exactly sure which of
the oddities was necessarily the culprit. Nonetheless, this is more
idiomatic Java threading/locking code.

Looking at the stack trace in the issue, it looks like the handling of
interrupts is the probable cause.